### PR TITLE
Bugfix/hero image

### DIFF
--- a/components/layout/hero/hero.js
+++ b/components/layout/hero/hero.js
@@ -25,7 +25,7 @@ export const Hero = ({
 }
 
 Hero.propTypes = {
-  backgroundImage: PropTypes.object,
+  backgroundImage: PropTypes.string,
   backgroundColor: PropTypes.string.isRequired,
   children: PropTypes.node,
 }


### PR DESCRIPTION
this PR addresses an warning thrown when an object is passed into the hero component `image` prop instead of a string (image path)