### PR TITLE
PersonGrid tweaks

### DIFF
--- a/components/people/index.js
+++ b/components/people/index.js
@@ -1,2 +1,3 @@
 export * from './person-card'
 export * from './person-grid'
+export * from './person-list'

--- a/components/people/person-list.js
+++ b/components/people/person-list.js
@@ -29,6 +29,8 @@ export const PersonList = ({ people, showTitles }) => {
         people.map(person => (
           <Card
             key={ `${ person.slug }-card` }
+            component={ Link }
+            to={ `/people/${ person.slug }` }
             className="profile-card"
             elevation={ 0 }
           >
@@ -39,9 +41,7 @@ export const PersonList = ({ people, showTitles }) => {
               className="photo"
             />
             <CardContent className="name-and-title">
-              <Link to={ `/people/${ person.slug }` }>
-                { person.firstName } { person.lastName }
-              </Link>
+              { person.firstName } { person.lastName }
               { showTitles && (
                 <Typography>{ person.title }</Typography>
               )}

--- a/components/people/person-list.js
+++ b/components/people/person-list.js
@@ -54,11 +54,12 @@ export const PersonList = ({ people, showTitles }) => {
 }
 
 PersonList.propTypes = {
-  children: PropTypes.node.isRequired,
+  people: PropTypes.array.isRequired,
   showTitles: PropTypes.bool.isRequired,
 }
 
 PersonList.defaultProps = {
+  people: [],
   showTitles: false,
 }
 

--- a/components/people/person-list.js
+++ b/components/people/person-list.js
@@ -41,7 +41,7 @@ export const PersonList = ({ people, showTitles }) => {
               className="photo"
             />
             <CardContent className="name-and-title">
-              { person.firstName } { person.lastName }
+              <Typography>{ person.firstName } { person.lastName }</Typography>
               { showTitles && (
                 <Typography>{ person.title }</Typography>
               )}

--- a/components/people/person-list.js
+++ b/components/people/person-list.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Box, Card, CardContent, CardMedia, Divider, Typography } from '@mui/material'
+import { Box, Card, CardContent, CardMedia, Typography } from '@mui/material'
 import { PersonCard } from './'
 import { Link } from '../'
 import avatar from '../../images/generic-avatar.png'
@@ -14,9 +14,13 @@ export const PersonList = ({ people, showTitles }) => {
       '& .profile-card': {
         flex: '1 1 200px',
         '& .photo': {
+          margin: 'auto',
           width: '200px',
           height: '200px',
-        }
+        },
+        '& .name-and-title': {
+          textAlign: 'center',
+        },
       },
     }}>
       {
@@ -32,8 +36,7 @@ export const PersonList = ({ people, showTitles }) => {
               alt={ `${ person.firstName } ${ person.lastName } headshot` }
               className="photo"
             />
-            <Divider />
-            <CardContent>
+            <CardContent className="name-and-title">
               <Link to={ `/people/${ person.slug }` }>
                 { person.firstName } { person.lastName }
               </Link>

--- a/components/people/person-list.js
+++ b/components/people/person-list.js
@@ -10,9 +10,11 @@ export const PersonList = ({ people, showTitles }) => {
     <Box sx={{
       display: 'flex',
       flexWrap: 'wrap',
+      justifyContent: 'flex-start',
       gap: '1rem',
       '& .profile-card': {
         flex: '1 1 200px',
+        maxWidth: '250px',
         '& .photo': {
           margin: 'auto',
           width: '200px',

--- a/components/people/person-list.js
+++ b/components/people/person-list.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Box, Card, CardContent, CardMedia, Divider, Typography } from '@mui/material'
+import { PersonCard } from './'
+import { Link } from '../'
+import avatar from '../../images/generic-avatar.png'
+
+export const PersonList = ({ people, showTitles }) => {
+  return (
+    <Box sx={{
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: '1rem',
+      '& .profile-card': {
+        flex: '1 1 200px',
+        '& .photo': {
+          width: '200px',
+          height: '200px',
+        }
+      },
+    }}>
+      {
+        people.map(person => (
+          <Card
+            key={ `${ person.slug }-card` }
+            className="profile-card"
+            elevation={ 0 }
+          >
+            <CardMedia
+              component="img"
+              image={ person.photo ? person.photo.url : avatar.src }
+              alt={ `${ person.firstName } ${ person.lastName } headshot` }
+              className="photo"
+            />
+            <Divider />
+            <CardContent>
+              <Link to={ `/people/${ person.slug }` }>
+                { person.firstName } { person.lastName }
+              </Link>
+              { showTitles && (
+                <Typography>{ person.title }</Typography>
+              )}
+            </CardContent>
+          </Card>
+        ))
+      }
+    </Box>
+  )
+}
+
+PersonList.propTypes = {
+  children: PropTypes.node.isRequired,
+  showTitles: PropTypes.bool.isRequired,
+}
+
+PersonList.defaultProps = {
+  showTitles: false,
+}
+

--- a/pages/groups/[id].js
+++ b/pages/groups/[id].js
@@ -4,7 +4,7 @@ import { Typography, Box } from '@mui/material'
 import { fetchResearchGroup } from '../../lib/contentful'
 import { Page } from '../../components'
 import { Section } from '../../components/layout'
-import { PersonCard, PersonGrid } from '../../components/people/'
+import { PersonList } from '../../components/people/'
 
 export default function ResearchGroup() {
   const router = useRouter()
@@ -41,13 +41,7 @@ export default function ResearchGroup() {
       </Section>
 
       <Section title="Contributors">
-        <PersonGrid>
-          {
-            researchGroup.groupMembersCollection.items.map(person => (
-              <PersonCard key={ person.slug } person={ person } showTitle={false}/>
-            ))
-          }
-        </PersonGrid>
+        <PersonList people={ researchGroup.groupMembersCollection.items } />
       </Section>
 
     </Page>


### PR DESCRIPTION
@suejinkim20 i'm proposing a couple changes to your PersonGrid component. to illustrate, i've created this branch, which has a PersonList component. here are some things i was hoping to address:

- the overall size of the people cards felt too large, so this reduced the size of the cards.
- the photos flexing is not ideal because of the different sizes and aspect ratios. to retain some flexibility of the gap between columns/rows, PersonList uses `flex : 1 1 200px`, while the images within have a fixed size. the image and words in the card are horizontally centered. so the columns feel flexy, but the images keep a fixed size.
- we talked about this one. linking the whole card to the person's profile instead of having to click their name. for this, i've used the component prop to render the Card as a Link.
- the last thing is i don't want us to want to have to construct the two-component nested Grid > Card every time we want to render people, so this PersonList component just takes an array of people and handles building the cards itself instead of taking children.

note that this doesn't make use of your PersonCard component. this was more of a sandbox/proof-of-concept/illustrative branch. there is work to be done to get this to a mergeable state, but i wanted to start the conversation, hence this PR.

what do you think?