### PR TITLE
add overflowY: auto to alphabet container

### DIFF
--- a/pages/people/index.js
+++ b/pages/people/index.js
@@ -95,8 +95,8 @@ export default function People({ people }) {
             maxHeight: 'calc(100vh - var(--distance-from-top) - 2rem)',
             marginTop: "2rem",
             alignSelf: "flex-start",
-            paddingRight: '4px',
-            scrollbarWidth: "none",
+            paddingX: '6px',
+            scrollbarWidth: "thin",
 
             "&::-webkit-scrollbar": {
               width: "4px",

--- a/pages/people/index.js
+++ b/pages/people/index.js
@@ -90,11 +90,27 @@ export default function People({ people }) {
             gap: "4px",
             position: "sticky",
             overflowY: "auto",
+            overflowX: "hidden",
             top: "var(--distance-from-top)",
             maxHeight: 'calc(100vh - var(--distance-from-top) - 2rem)',
             marginTop: "2rem",
             alignSelf: "flex-start",
-            paddingRight: '8px',
+            paddingRight: '2px',
+
+            "&::-webkit-scrollbar": {
+              width: "4px",
+            },
+            "&::-webkit-scrollbar-track": {
+              backgroundColor: "transparent",
+            },
+            "&::-webkit-scrollbar-thumb": {
+              backgroundColor: "transparent",
+              borderRadius: "2px",
+            },
+            "&:hover::-webkit-scrollbar-thumb": {
+              backgroundColor: "rgba(0, 0, 0, 0.3)",
+            }
+
           }}
         >
           {letters.map((letter) =>

--- a/pages/people/index.js
+++ b/pages/people/index.js
@@ -82,15 +82,19 @@ export default function People({ people }) {
         <Box
           component="nav"
           sx={{
+            '--distance-from-top': '10rem',
             display: "flex",
             flexDirection: "column",
             alignItems: "center",
             justifyContent: "flex-start",
             gap: "4px",
             position: "sticky",
-            top: "10rem",
+            overflowY: "auto",
+            top: "var(--distance-from-top)",
+            maxHeight: 'calc(100vh - var(--distance-from-top) - 2rem)',
             marginTop: "2rem",
             alignSelf: "flex-start",
+            paddingRight: '8px',
           }}
         >
           {letters.map((letter) =>

--- a/pages/people/index.js
+++ b/pages/people/index.js
@@ -95,7 +95,8 @@ export default function People({ people }) {
             maxHeight: 'calc(100vh - var(--distance-from-top) - 2rem)',
             marginTop: "2rem",
             alignSelf: "flex-start",
-            paddingRight: '2px',
+            paddingRight: '4px',
+            scrollbarWidth: "none",
 
             "&::-webkit-scrollbar": {
               width: "4px",


### PR DESCRIPTION
Found a potential solution to allow the letter selector on the people page to be used on smaller screens. Basically it's this SO answer:

[https://stackoverflow.com/questions/37752448/css-position-sticky-and-overflow](https://stackoverflow.com/questions/37752448/css-position-sticky-and-overflow  )

It's not ideal because it won't fill 100% of the available space. Rather it allows the container to grow to a fraction of the vertical screen space, and then the `overflowY: auto` kicks in. There's more details in the commit message if needed.