### PR TITLE
Research group page data template

### DIFF
--- a/lib/strapi/groupsGraphQL.js
+++ b/lib/strapi/groupsGraphQL.js
@@ -62,6 +62,7 @@ export const fetchStrapiGroup = async (id, preview = false) => {
           projects {
             data {
               attributes {
+                active
                 slug
                 name
               }
@@ -93,6 +94,7 @@ export const fetchStrapiGroup = async (id, preview = false) => {
     projects: groupData.researchGroups.data[0].attributes.projects.data ? groupData.researchGroups.data[0].attributes.projects.data.map((project) => ({
       slug: project.attributes.slug,
       name: project.attributes.name,
+      active: project.attributes.active,
     })) : [],
   }
 

--- a/lib/strapi/groupsGraphQL.js
+++ b/lib/strapi/groupsGraphQL.js
@@ -84,6 +84,7 @@ export const fetchStrapiGroup = async (id, preview = false) => {
   // the groups query and the people query
   const payload = {
     id: groupData.researchGroups.data[0].id,
+    featuredImage: groupData.researchGroups.data[0].attributes.featuredImage.data.attributes,
     name: groupData.researchGroups.data[0].attributes.name,
     description: groupData.researchGroups.data[0].attributes.description,
     role: groupData.researchGroups.data[0].attributes.role,

--- a/lib/strapi/groupsGraphQL.js
+++ b/lib/strapi/groupsGraphQL.js
@@ -68,6 +68,15 @@ export const fetchStrapiGroup = async (id, preview = false) => {
               }
             }
           }
+          partners {
+            data {
+              attributes {
+                name
+                url
+                slug
+              }
+            }
+          }
         }
       }
     }
@@ -95,6 +104,11 @@ export const fetchStrapiGroup = async (id, preview = false) => {
       slug: project.attributes.slug,
       name: project.attributes.name,
       active: project.attributes.active,
+    })) : [],
+    partners: groupData.researchGroups.data[0].attributes.partners.data ? groupData.researchGroups.data[0].attributes.partners.data.map((partner) => ({
+      name: partner.attributes.name,
+      url: partner.attributes.url,
+      slug: partner.attributes.slug,
     })) : [],
   }
 

--- a/pages/groups/[id].js
+++ b/pages/groups/[id].js
@@ -60,6 +60,22 @@ export default function ResearchGroup() {
         </PersonGrid>
       </Section>
 
+      {researchGroup.partners.length > 0 && 
+        <Section title="Partners">
+          <ul>
+            {
+              researchGroup.partners
+                .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
+                .map(partner => (
+                  <li key={ `${ researchGroup.name }-${ partner.name }` }>
+                    <Link to={ partner.url }>{ partner.name }</Link>
+                  </li>
+                ))
+            }
+          </ul>
+        </Section>
+      }
+
       {researchGroup.projects.some(project => project.active === false) && 
         <Section title="Past Projects">
           <ul>

--- a/pages/groups/[id].js
+++ b/pages/groups/[id].js
@@ -38,6 +38,7 @@ export default function ResearchGroup() {
           {
             researchGroup.projects
               .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
+              .filter(project => !project.active)
               .map(project => (
                 <li key={ `${ researchGroup.name }-${ project.name }` }>
                   <Link to={ `/projects/${ project.slug }` }>{ project.name }</Link>

--- a/pages/groups/[id].js
+++ b/pages/groups/[id].js
@@ -47,13 +47,10 @@ export default function ResearchGroup() {
         </ul>
       </Section>
 
-      {/* <Section title="Contributors">
-        <PersonList people={ researchGroup.members } />
-      </Section> */}
       <Section title="Team Members">
        <PersonGrid>
           {
-            researchGroup.members.map(person => (
+            researchGroup.members.filter(person => person.active).map(person => (
               <PersonCard key={ person.slug } person={ person } showTitle={true}/>
             ))
           }

--- a/pages/groups/[id].js
+++ b/pages/groups/[id].js
@@ -38,7 +38,7 @@ export default function ResearchGroup() {
           {
             researchGroup.projects
               .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
-              .filter(project => !project.active)
+              .filter(project => project.active === true || 'null')
               .map(project => (
                 <li key={ `${ researchGroup.name }-${ project.name }` }>
                   <Link to={ `/projects/${ project.slug }` }>{ project.name }</Link>
@@ -58,6 +58,22 @@ export default function ResearchGroup() {
         </PersonGrid>
       </Section>
 
+      {researchGroup.projects.some(project => project.active === false) && 
+        <Section title="Past Projects">
+          <ul>
+            {
+              researchGroup.projects
+                .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
+                .filter(project => project.active === false)
+                .map(project => (
+                  <li key={ `${ researchGroup.name }-${ project.name }` }>
+                    <Link to={ `/projects/${ project.slug }` }>{ project.name }</Link>
+                  </li>
+                ))
+            }
+          </ul>
+        </Section>
+      }
     </Page>
   )
 }

--- a/pages/groups/[id].js
+++ b/pages/groups/[id].js
@@ -33,20 +33,22 @@ export default function ResearchGroup() {
       <Typography paragraph>{researchGroup.description}</Typography>
       <br/>
       
-      <Section title="Current Projects">
-        <ul>
-          {
-            researchGroup.projects
-              .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
-              .filter(project => project.active === true || 'null')
-              .map(project => (
-                <li key={ `${ researchGroup.name }-${ project.name }` }>
-                  <Link to={ `/projects/${ project.slug }` }>{ project.name }</Link>
-                </li>
-              ))
-          }
-        </ul>
-      </Section>
+      {researchGroup.projects.some(project => project.active === true || 'null') &&
+        <Section title="Current Projects">
+          <ul>
+            {
+              researchGroup.projects
+                .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
+                .filter(project => project.active === true || 'null')
+                .map(project => (
+                  <li key={ `${ researchGroup.name }-${ project.name }` }>
+                    <Link to={ `/projects/${ project.slug }` }>{ project.name }</Link>
+                  </li>
+                ))
+            }
+          </ul>
+        </Section>
+      }
 
       <Section title="Team Members">
        <PersonGrid>


### PR DESCRIPTION
This PR gets and displays all the data currently available from strapi for the `groups/[slug].js` template. Styles will be tweaked and unified across other pages in a future change