### PR TITLE
Improve section styles

### DIFF
--- a/components/layout/section/section.js
+++ b/components/layout/section/section.js
@@ -7,7 +7,7 @@ export const Section = ({ title, children }) => {
     direction={{ sm: 'column', md: 'row' }}
     spacing={{ sm: 2, md: 6 }}
     sx={{
-        margin: '3rem 0',
+        marginY: '3rem',
         '& .title': {
           xs: { textAlign: 'left' },
           md: { textAlign: 'right' },
@@ -22,7 +22,7 @@ export const Section = ({ title, children }) => {
       }}>
         {
           title && (
-            <Typography variant="h2" className="title" textAlign="right" >
+            <Typography variant="h2" className="title" >
               { title }
             </Typography>
           )

--- a/components/layout/section/section.js
+++ b/components/layout/section/section.js
@@ -7,7 +7,7 @@ export const Section = ({ title, children }) => {
     direction={{ sm: 'column', md: 'row' }}
     spacing={{ sm: 2, md: 6 }}
     sx={{
-        margin: '3rem 6rem',
+        margin: '3rem 0',
         '& .title': {
           xs: { textAlign: 'left' },
           md: { textAlign: 'right' },
@@ -17,18 +17,18 @@ export const Section = ({ title, children }) => {
       <Box sx={{
         flex: {
           sm: '0 0',
-          md: '0 0 200px'
+          md: `0 0 ${255 / 16}rem`
         }
       }}>
         {
           title && (
-            <Typography variant="h2" className="title">
+            <Typography variant="h2" className="title" textAlign="right" >
               { title }
             </Typography>
           )
         }
       </Box>
-      <Box sx={{ flex: '4' , wordWrap: 'break-word'}} >
+      <Box sx={{ flex: '1' , wordWrap: 'break-word'}} >
           { children }
       </Box>
     </Stack>

--- a/components/layout/text-image-section/text-image-section.js
+++ b/components/layout/text-image-section/text-image-section.js
@@ -5,16 +5,15 @@ import PropTypes from 'prop-types'
 export const TextImageSection = ({ imageUrl, imageHeight, imageWidth, children }) => (
   <Stack
     direction={{ sm: 'column', md: 'row' }}
-    spacing={ 2 }
+    spacing={{ sm: 2, md: 6 }}
     sx={{
-      marginY: '2rem',
-      gap: '2rem',
+      marginY: '3rem',
     }}
   >
     {imageUrl && <Box sx={{
       flex: {
-        sm: '1',
-        md: '1'
+        sm: '0 0',
+        md: `0 0 ${255 / 16}rem`
       },
     }}>
       <Image
@@ -25,7 +24,7 @@ export const TextImageSection = ({ imageUrl, imageHeight, imageWidth, children }
         layout="responsive"
       />
     </Box>}
-    <Box sx={{ flex: '3' }}>
+    <Box sx={{ flex: '1' }}>
       {children}
     </Box>
   </Stack>

--- a/components/people/person-card.js
+++ b/components/people/person-card.js
@@ -9,17 +9,16 @@ export const PersonCard = ({ person, showTitle = false, anchorName }) => {
       <Card elevation={ 0 } name={ anchorName }>
         <CardMedia
           component="img"
-          height="250"
           image={ person.photoURL ? person.photoURL : avatar.src }
           alt={ `${person.firstName} ${person.lastName} photo` }
         />
 
-        <CardContent>
+        <CardContent sx={{ display: 'flex', flexDirection: 'column' }}>
           <Link to={ `/people/${ person.slug }` }>
             { person.firstName } { person.lastName }
           </Link>
           { showTitle && person.title && (
-            <Typography>{ person.title }</Typography>
+            <Typography variant='caption'>{ person.title }</Typography>
           )}
         </CardContent>
       </Card>

--- a/components/people/person-card.js
+++ b/components/people/person-card.js
@@ -9,6 +9,7 @@ export const PersonCard = ({ person, showTitle = false, anchorName }) => {
       <Card elevation={ 0 } name={ anchorName }>
         <CardMedia
           component="img"
+          height='250px'
           image={ person.photoURL ? person.photoURL : avatar.src }
           alt={ `${person.firstName} ${person.lastName} photo` }
         />

--- a/components/people/person-grid.js
+++ b/components/people/person-grid.js
@@ -2,14 +2,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Box } from '@mui/material'
 
-export const PersonGrid = ({ children }) => {
+export const PersonGrid = ({ children, size }) => {
   return (
     <Box sx={{
       flex: 1,
-      marginTop: '3rem',
       display: 'grid',
-      gap: '2rem',
-      gridTemplateColumns: 'repeat(auto-fit, 250px)',
+      gap: '3rem',
+      gridTemplateColumns: `repeat(${size === 'small' ? 5 : 4}, 1fr)`,
     }}>
       { children }
     </Box>
@@ -18,4 +17,5 @@ export const PersonGrid = ({ children }) => {
 
 PersonGrid.propTypes = {
   children: PropTypes.node.isRequired,
+  size: PropTypes.oneOf(['small', 'large'])
 }

--- a/components/people/person-grid.js
+++ b/components/people/person-grid.js
@@ -2,13 +2,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Box } from '@mui/material'
 
-export const PersonGrid = ({ children, size }) => {
+export const PersonGrid = ({ children }) => {
   return (
     <Box sx={{
       flex: 1,
       display: 'grid',
-      gap: '3rem',
-      gridTemplateColumns: `repeat(auto-fit, ${size === 'small' ? '175px' : '285px'})`,
+      gap: '2rem',
+      gridTemplateColumns: `repeat(auto-fit, 250px)`,
     }}>
       { children }
     </Box>

--- a/components/people/person-grid.js
+++ b/components/people/person-grid.js
@@ -8,7 +8,7 @@ export const PersonGrid = ({ children, size }) => {
       flex: 1,
       display: 'grid',
       gap: '3rem',
-      gridTemplateColumns: `repeat(${size === 'small' ? 5 : 4}, 1fr)`,
+      gridTemplateColumns: `repeat(auto-fit, ${size === 'small' ? '175px' : '285px'})`,
     }}>
       { children }
     </Box>

--- a/pages/collaborations/[id].js
+++ b/pages/collaborations/[id].js
@@ -35,7 +35,7 @@ export default function Collaboration() {
       </Section>
 
       <Section title="Projects">
-        <ul>
+        <ul style={{ margin: 0 }}>
           {
             collaboration.projects
               .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)

--- a/pages/groups/[id].js
+++ b/pages/groups/[id].js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
-import { Typography, Box } from '@mui/material'
+import { Typography, Box, Divider } from '@mui/material'
 import { fetchStrapiGroup } from '../../lib/strapi'
 import { Link, Page, Pre } from '../../components'
 import { Section } from '../../components/layout'
@@ -34,22 +34,26 @@ export default function ResearchGroup() {
       <br/>
       
       {researchGroup.projects.some(project => project.active === true || 'null') &&
-        <Section title="Current Projects">
-          <ul style={{ margin: 0 }}>
-            {
-              researchGroup.projects
-                .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
-                .filter(project => project.active === true || 'null')
-                .map(project => (
-                  <li key={ `${ researchGroup.name }-${ project.name }` }>
-                    <Link to={ `/projects/${ project.slug }` }>{ project.name }</Link>
-                  </li>
-                ))
-            }
-          </ul>
-        </Section>
+        <>
+          <Divider />
+          <Section title="Current Projects">
+            <ul style={{ margin: 0 }}>
+              {
+                researchGroup.projects
+                  .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
+                  .filter(project => project.active === true || 'null')
+                  .map(project => (
+                    <li key={ `${ researchGroup.name }-${ project.name }` }>
+                      <Link to={ `/projects/${ project.slug }` }>{ project.name }</Link>
+                    </li>
+                  ))
+              }
+            </ul>
+          </Section>
+        </>
       }
 
+      <Divider />
       <Section title="Team Members">
        <PersonGrid>
           {
@@ -61,36 +65,42 @@ export default function ResearchGroup() {
       </Section>
 
       {researchGroup.partners.length > 0 && 
-        <Section title="Partners">
-          <ul style={{ margin: 0 }}>
-            {
-              researchGroup.partners
-                .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
-                .map(partner => (
-                  <li key={ `${ researchGroup.name }-${ partner.name }` }>
-                    <Link to={ partner.url }>{ partner.name }</Link>
-                  </li>
-                ))
-            }
-          </ul>
-        </Section>
+        <>
+          <Divider />
+          <Section title="Partners">
+            <ul style={{ margin: 0 }}>
+              {
+                researchGroup.partners
+                  .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
+                  .map(partner => (
+                    <li key={ `${ researchGroup.name }-${ partner.name }` }>
+                      <Link to={ partner.url }>{ partner.name }</Link>
+                    </li>
+                  ))
+              }
+            </ul>
+          </Section>
+        </>
       }
 
       {researchGroup.projects.some(project => project.active === false) && 
-        <Section title="Past Projects">
-          <ul style={{ margin: 0 }}>
-            {
-              researchGroup.projects
-                .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
-                .filter(project => project.active === false)
-                .map(project => (
-                  <li key={ `${ researchGroup.name }-${ project.name }` }>
-                    <Link to={ `/projects/${ project.slug }` }>{ project.name }</Link>
-                  </li>
-                ))
-            }
-          </ul>
-        </Section>
+        <>
+          <Divider />
+          <Section title="Past Projects">
+            <ul style={{ margin: 0 }}>
+              {
+                researchGroup.projects
+                  .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
+                  .filter(project => project.active === false)
+                  .map(project => (
+                    <li key={ `${ researchGroup.name }-${ project.name }` }>
+                      <Link to={ `/projects/${ project.slug }` }>{ project.name }</Link>
+                    </li>
+                  ))
+              }
+            </ul>
+          </Section>
+        </>
       }
     </Page>
   )

--- a/pages/groups/[id].js
+++ b/pages/groups/[id].js
@@ -35,7 +35,7 @@ export default function ResearchGroup() {
       
       {researchGroup.projects.some(project => project.active === true || 'null') &&
         <Section title="Current Projects">
-          <ul>
+          <ul style={{ margin: 0 }}>
             {
               researchGroup.projects
                 .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
@@ -62,7 +62,7 @@ export default function ResearchGroup() {
 
       {researchGroup.partners.length > 0 && 
         <Section title="Partners">
-          <ul>
+          <ul style={{ margin: 0 }}>
             {
               researchGroup.partners
                 .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
@@ -78,7 +78,7 @@ export default function ResearchGroup() {
 
       {researchGroup.projects.some(project => project.active === false) && 
         <Section title="Past Projects">
-          <ul>
+          <ul style={{ margin: 0 }}>
             {
               researchGroup.projects
                 .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)

--- a/pages/people/[slug].js
+++ b/pages/people/[slug].js
@@ -79,7 +79,6 @@ export default function Person() {
           }
       </TextImageSection>
 
-      <br /><br />
       {
         person.contributions && (
           <Fragment>

--- a/pages/people/[slug].js
+++ b/pages/people/[slug].js
@@ -1,9 +1,8 @@
 import { useEffect, useState, Fragment } from 'react'
 import { useRouter } from 'next/router'
-import Image from 'next/image'
-import { Divider, Grid, Typography } from '@mui/material'
+import { Divider, Typography } from '@mui/material'
 import { fetchStrapiPerson } from "../../lib/strapi";
-import { Link, LinkTray, Page, Pre, Section } from '../../components'
+import { Link, Page, Section, TextImageSection } from '../../components'
 
 export default function Person() {
   const router = useRouter()
@@ -25,18 +24,11 @@ export default function Person() {
 
   return (
     <Page title={ `${ person.firstName } ${ person.lastName }` } hideTitle>
-      <Grid container spacing={ 6 } columns={ 8 } sx={{marginLeft: '3rem', marginRight: '3rem'}}>
-        <Grid item xs={ 8 } sm={ 2 }>
-          <Image
-            priority
-            src={ person.photoURL }
-            width={ 400 }
-            height={ 400 }
-            layout="responsive"
-            alt={`${person.slug}-photo`}
-          />
-        </Grid>
-        <Grid item xs={ 8 } sm={ 6}>
+      <TextImageSection 
+        imageUrl={ person.photoURL }
+        imageWidth={ '400px' }
+        imageHeight={ '400px' }
+        >
           <Typography variant="h1" >
             { person.fullName }
           </Typography>
@@ -85,13 +77,8 @@ export default function Person() {
               <Typography paragraph>{ person.phoneNumber }</Typography>
             )
           }
-          {/*
-            Will need to add to the content
-            model to be able to use this.
-            <LinkTray urls={  } />
-          */}
-        </Grid>
-      </Grid>
+      </TextImageSection>
+
       <br /><br />
       {
         person.contributions && (

--- a/pages/people/index.js
+++ b/pages/people/index.js
@@ -62,23 +62,21 @@ export default function People({ people }) {
 
       <Typography variant="h2">Office of the Director</Typography>
 
-      <br /><br />
-
-      <PersonGrid>
-        {people.ood.map((person) => (
-          <PersonCard
-            key={person.slug}
-            person={person}
-            showTitle={true}
-          />
-        ))}
-      </PersonGrid>
-
-      <br /><br />
+      <Box my='2rem'>
+        <PersonGrid size='large'>
+          {people.ood.map((person) => (
+            <PersonCard
+              key={person.slug}
+              person={person}
+              showTitle={true}
+            />
+          ))}
+        </PersonGrid>
+      </Box>
 
       <Typography variant="h2">Everyone Else</Typography>
 
-      <Box sx={{ display: "flex", gap: "1rem" }}>
+      <Box sx={{ display: "flex", gap: "1rem", my: '2rem' }}>
         <Box
           component="nav"
           sx={{
@@ -93,7 +91,6 @@ export default function People({ people }) {
             overflowX: "hidden",
             top: "var(--distance-from-top)",
             maxHeight: 'calc(100vh - var(--distance-from-top) - 2rem)',
-            marginTop: "2rem",
             alignSelf: "flex-start",
             paddingX: '6px',
             scrollbarWidth: "thin",
@@ -130,7 +127,7 @@ export default function People({ people }) {
             )
           )}
         </Box>
-        <PersonGrid>
+        <PersonGrid size='small'>
           {
             people.people
               .map(person => {

--- a/pages/people/index.js
+++ b/pages/people/index.js
@@ -63,7 +63,7 @@ export default function People({ people }) {
       <Typography variant="h2">Office of the Director</Typography>
 
       <Box my='2rem'>
-        <PersonGrid size='large'>
+        <PersonGrid>
           {people.ood.map((person) => (
             <PersonCard
               key={person.slug}
@@ -127,7 +127,7 @@ export default function People({ people }) {
             )
           )}
         </Box>
-        <PersonGrid size='small'>
+        <PersonGrid>
           {
             people.people
               .map(person => {

--- a/pages/projects/[id].js
+++ b/pages/projects/[id].js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
-import { Typography } from '@mui/material'
+import { Divider, Typography } from '@mui/material'
 import { fetchStrapiProject } from '../../lib/strapi'
 import { Link, Page } from '../../components'
 import { Pre } from '../../components/pre'
@@ -45,46 +45,38 @@ export default function Project() {
       <br/>
       {
         project.renciRole && (
-          <Section title="RENCI's Role">
-            <Typography paragraph>{project.renciRole}</Typography>
-          </Section>
+          <>
+            <Divider />
+            <Section title="RENCI's Role">
+              <Typography paragraph>{project.renciRole}</Typography>
+            </Section>
+          </>
         )
       }
       {
         project.members.length > 0 && (
-          <Section title="Team Members">
-            <PersonGrid>
-              {
-                project.members.filter(person => person.active).map(person => (
-                  <PersonCard key={ person.slug } person={ person } showTitle={true}/>
-                ))
-              }
-            </PersonGrid>
-          </Section>
+          <>
+            <Divider />
+            <Section title="Team Members">
+              <PersonGrid>
+                {
+                  project.members.filter(person => person.active).map(person => (
+                    <PersonCard key={ person.slug } person={ person } showTitle={true}/>
+                  ))
+                }
+              </PersonGrid>
+            </Section>
+          </>
         )
       }
       {
         project.partners.length > 0 && 
-        <Section title="Partners">
-          <ul style={{ margin: 0 }}>
-            {
-              project.partners
-                .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
-                .map(partner => (
-                  <li key={ `${ project.name }-${ partner.name }` }>
-                    <Link to={ partner.url }>{ partner.name }</Link>
-                  </li>
-                ))
-            }
-          </ul>
-        </Section>
-      }
-      {
-        project.funding.length > 0 && 
-          <Section title="Funding">
+        <>
+          <Divider />
+          <Section title="Partners">
             <ul style={{ margin: 0 }}>
               {
-                project.funding
+                project.partners
                   .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
                   .map(partner => (
                     <li key={ `${ project.name }-${ partner.name }` }>
@@ -94,6 +86,26 @@ export default function Project() {
               }
             </ul>
           </Section>
+        </>
+      }
+      {
+        project.funding.length > 0 && 
+          <>
+            <Divider />
+            <Section title="Funding">
+              <ul style={{ margin: 0 }}>
+                {
+                  project.funding
+                    .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
+                    .map(partner => (
+                      <li key={ `${ project.name }-${ partner.name }` }>
+                        <Link to={ partner.url }>{ partner.name }</Link>
+                      </li>
+                    ))
+                }
+              </ul>
+            </Section>
+          </>
         }
     </Page>
   )

--- a/pages/projects/[id].js
+++ b/pages/projects/[id].js
@@ -66,7 +66,7 @@ export default function Project() {
       {
         project.partners.length > 0 && 
         <Section title="Partners">
-          <ul>
+          <ul style={{ margin: 0 }}>
             {
               project.partners
                 .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)
@@ -82,7 +82,7 @@ export default function Project() {
       {
         project.funding.length > 0 && 
           <Section title="Funding">
-            <ul>
+            <ul style={{ margin: 0 }}>
               {
                 project.funding
                   .sort((p, q) => p.name.toLowerCase() < q.name.toLowerCase() ? -1 : 1)

--- a/pages/teams/index.js
+++ b/pages/teams/index.js
@@ -28,7 +28,7 @@ export default function Teams({ teams }) {
         Learn more about RENCI&apos;s Operations teams below.
       </Typography>
 
-      <ul>
+      <ul style={{ margin: 0 }}>
         {
           teams.map(team => (
             <li key={ `link-to-${ team.name }` }>


### PR DESCRIPTION
I lined up some of the styling:

- removed x-direction margin on the section components so they now fill the whole wrapper
- increased the section heading flex-basis, so titles don't wrap as much
- use the `<TextImageSection />` component for bio image/info card on `people/[slug].js`
    - also matched that component to line up with `<Section />`
- removed margin on some `ul`s to match with headings. We will probably want a custom `ul` component in the future.

I attempted to change the photo card styles, but those are used on several pages and I couldn't easily find a good way to get them to look right on all pages, so I figure that can be a separate PR.