### PR TITLE
make access token public for clients to use

### DIFF
--- a/lib/strapi/fetchStrapiGraphQL.js
+++ b/lib/strapi/fetchStrapiGraphQL.js
@@ -3,7 +3,7 @@ export const fetchStrapiGraphQL = async (query, preview = false) => {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${process.env.ACCESS_TOKEN}`,
+      Authorization: `Bearer ${process.env.NEXT_PUBLIC_ACCESS_TOKEN}`,
     },
     body: JSON.stringify({ query }),
   }).then((response) => response.json());

--- a/utils/api.js
+++ b/utils/api.js
@@ -10,7 +10,7 @@ export async function fetchAPI(path, options = {}) {
     headers: {
       "Content-Type": "application/json",
       Authorization:
-          `Bearer ${process.env.ACCESS_TOKEN}`,
+          `Bearer ${process.env.NEXT_PUBLIC_ACCESS_TOKEN}`,
     },
   };
   const mergedOptions = {


### PR DESCRIPTION
Swapped to NEXT_PUBLIC_ACCESS_TOKEN as we need the client to make one request for the "Our Work" section.

[Documentation](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser)