### PR TITLE
remove standalone build output that was breaking amplify

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,9 +16,6 @@ module.exports = {
   // images: {
   //   domains: ["heal-community-portal-api.s3.amazonaws.com"],
   // },
-  experimental: {
-    outputStandalone: true,
-  },
   i18n: {
     locales: ["en"],
     defaultLocale: "en",


### PR DESCRIPTION
This is an important flag for the kubernetes deploy, but breaks the Amplify automated deploy. Let's remove it on the `develop` branch so we can keep Amplify until we're ready to completely swap to k8s. I will add this build config to the `update/kubernetes` branch so we can use that to do k8s deploys in the meantime.