### PR TITLE
Build static pages

### DIFF
--- a/lib/strapi/newsGraphQL.js
+++ b/lib/strapi/newsGraphQL.js
@@ -131,8 +131,6 @@ export const fetchArticle = async (slug) => {
     fetchPhotoThumbnailUrl(attributes.slug)
   )))
 
-  console.log(photos);
-
   return await articleGql.data.posts.data.map(({ attributes }) => ({
     ...attributes,
     renciAuthors: attributes.renciAuthors.data.map(({ attributes }, i) => ({

--- a/pages/collaborations/index.js
+++ b/pages/collaborations/index.js
@@ -46,14 +46,12 @@ export default function ResearchGroups({ collaborations }) {
   )
 }
 
-export async function getServerSideProps({ res }) {
-  res.setHeader(
-    'Cache-Control',
-    'no-cache, no-store, must-revalidate'
-  )
-  
+export async function getStaticProps() {
   const collaborations = await fetchStrapiCollaborations()
   return {
-    props: { collaborations: JSON.parse(JSON.stringify(collaborations)) },
+    props: {
+      collaborations: JSON.parse(JSON.stringify(collaborations)),
+      revalidate: 3600,
+    },
   }
 }

--- a/pages/groups/index.js
+++ b/pages/groups/index.js
@@ -39,14 +39,10 @@ export default function ResearchGroups({ researchGroups }) {
   )
 }
 
-export async function getServerSideProps({ res }) {
-  res.setHeader(
-    'Cache-Control',
-    'no-cache, no-store, must-revalidate'
-  )
-  
+export async function getStaticProps() {
   const researchGroups = await fetchStrapiGroups()
   return {
     props: { researchGroups: JSON.parse(JSON.stringify(researchGroups)) },
+    revalidate: 3600,
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -28,12 +28,7 @@ export default function Home({ selectedProjects}) {
   )
 }
 
-export async function getServerSideProps({ res }) {
-  res.setHeader(
-    'Cache-Control',
-    'no-cache, no-store, must-revalidate'
-  )
-  
+export async function getStaticProps() {
   const projects = await fetchActiveStrapiProjects()
 
   let projectsCopy = [...projects]
@@ -48,6 +43,9 @@ export async function getServerSideProps({ res }) {
   }
 
   return {
-    props: { selectedProjects: JSON.parse(JSON.stringify(projectSelection)) },
+    props: {
+      selectedProjects: JSON.parse(JSON.stringify(projectSelection)),
+      revalidate: 3600,
+    },
   }
 }

--- a/pages/news/[year]/[month]/[day]/index.js
+++ b/pages/news/[year]/[month]/[day]/index.js
@@ -70,9 +70,6 @@ export async function getStaticProps({ params }) {
     }
   `);
 
-  console.log(dateStr);
-  console.log(postsGql);
-
   const posts = postsGql.data.posts.data.map(({ attributes }) => attributes);
 
   return {

--- a/pages/news/appearances.js
+++ b/pages/news/appearances.js
@@ -114,15 +114,13 @@ export default function NewsAppearances({ appearances }) {
   );
 }
 
-export async function getServerSideProps({ res }) {
-  res.setHeader(
-    'Cache-Control',
-    'no-cache, no-store, must-revalidate'
-  )
-  
+export async function getStaticProps({ res }) {
   const appearances = await fetchAllNewsAppearances();
 
   return {
-    props: { appearances: JSON.parse(JSON.stringify(appearances)) },
+    props: {
+      appearances: JSON.parse(JSON.stringify(appearances)),
+      revalidate: 3600,
+    },
   };
 }

--- a/pages/people/index.js
+++ b/pages/people/index.js
@@ -155,15 +155,11 @@ export default function People({ people }) {
   );
 }
 
-export async function getServerSideProps({ res }) {
-  res.setHeader(
-    'Cache-Control',
-    'no-cache, no-store, must-revalidate'
-  )
-  
+export async function getStaticProps() {
   const people = await fetchStrapiPeople();
 
   return {
     props: { people: JSON.parse(JSON.stringify(people)) },
+    revalidate: 3600,
   };
 }

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -63,15 +63,13 @@ export default function Projects({ projects, size = 'medium' }) {
   )
 }
 
-export async function getServerSideProps({ res }) {
-  res.setHeader(
-    'Cache-Control',
-    'no-cache, no-store, must-revalidate'
-  )
-  
+export async function getStaticProps() {
   const projects = await fetchAllStrapiProjects();
 
   return {
-    props: { projects: JSON.parse(JSON.stringify(projects)) },
+    props: {
+      projects: JSON.parse(JSON.stringify(projects)),
+      revalidate: 3600,
+    },
   };
 }

--- a/pages/teams/index.js
+++ b/pages/teams/index.js
@@ -44,15 +44,13 @@ export default function Teams({ teams }) {
   )
 }
 
-export async function getServerSideProps({ res }) {
-  res.setHeader(
-    'Cache-Control',
-    'no-cache, no-store, must-revalidate'
-  )
-  
+export async function getStaticProps() {
   const teams = await fetchStrapiTeams()
 
   return {
-    props: { teams: JSON.parse(JSON.stringify(teams)) },
+    props: {
+      teams: JSON.parse(JSON.stringify(teams)),
+      revalidate: 3600,
+    },
   }
 }


### PR DESCRIPTION
This is in progress, I've started by changing the static route pages to getStaticProps. The dynamic routes ([slug].js) will need to have a path fetching function.

Routes changed so far:
- `/collaborations`
- `/groups`
- `/`
- `/news/appearances`
- `/people`
- `/projects`
- `/teams`