### PR TITLE
add link to all projects on the megamenu

### DIFF
--- a/components/layout/menu/our-work-tray.js
+++ b/components/layout/menu/our-work-tray.js
@@ -1,4 +1,4 @@
-import { Container, Fade, Grid, List, ListItem, ListSubheader, Paper, Typography } from '@mui/material'
+import { Container, Fade, Grid, List, ListItem, ListSubheader, Paper, Divider, Typography } from '@mui/material'
 import style from './menu.module.css'
 import { useConfig } from '../../../context'
 import { Link } from '../../'
@@ -54,6 +54,7 @@ export const OurWorkTray = ({
                   ))
                 }
                 {/* Add a one-off menu item that links to the list of all RENCI projects */}
+                <Divider sx={{ paddingTop: '0.5rem' }}/>
                 <ListItem sx={{ padding: '0.5rem' }}>
                   <Link to="/projects">All Projects</Link>
                 </ListItem>

--- a/components/layout/menu/our-work-tray.js
+++ b/components/layout/menu/our-work-tray.js
@@ -53,6 +53,10 @@ export const OurWorkTray = ({
                     </ListItem>
                   ))
                 }
+                {/* Add a one-off menu item that links to the list of all RENCI projects */}
+                <ListItem sx={{ padding: '0.5rem' }}>
+                  <Link to="/projects">All Projects</Link>
+                </ListItem>
               </List>
             </Grid>
             

--- a/components/layout/menu/our-work-tray.js
+++ b/components/layout/menu/our-work-tray.js
@@ -55,8 +55,8 @@ export const OurWorkTray = ({
                 }
                 {/* Add a one-off menu item that links to the list of all RENCI projects */}
                 <Divider sx={{ paddingTop: '0.5rem' }}/>
-                <ListItem sx={{ padding: '0.5rem' }}>
-                  <Link to="/projects">All Projects</Link>
+                <ListItem sx={{ padding: '0.5rem', fontWeight: '500' }}>
+                  <Link to="/projects">See All Projects</Link>
                 </ListItem>
               </List>
             </Grid>


### PR DESCRIPTION
This will add a link under the "Research Groups" column for which the text is "All Projects" and will link to `/projects` .

![Screenshot 2023-12-19 at 10 32 19 AM](https://github.com/mbwatson/renci-dot-org/assets/74567117/2c8d6a82-e110-4114-97dd-c9b9f767d928)
