### PR TITLE
use the NEXT_PUBLIC_STRAPI_API_URL env var if set

### DIFF
--- a/lib/strapi/fetchHomeNews.js
+++ b/lib/strapi/fetchHomeNews.js
@@ -1,3 +1,5 @@
+import { getStrapiURL } from "@/utils/api";
+
 export const fetchHomeNews = async (preview = false) => {
   try {
     let bodyContent = JSON.stringify({
@@ -7,7 +9,7 @@ export const fetchHomeNews = async (preview = false) => {
       }
     });
 
-    const response = await fetch('https://api.renci.org/api/post-list', {
+    const response = await fetch(getStrapiURL('/api/post-list'), {
       method: "POST",
       headers: {
         'Content-Type': 'application/json',

--- a/lib/strapi/fetchStrapiGraphQL.js
+++ b/lib/strapi/fetchStrapiGraphQL.js
@@ -1,5 +1,7 @@
+import { getStrapiURL } from "@/utils/api";
+
 export const fetchStrapiGraphQL = async (query, preview = false, signal = undefined) => {
-  return fetch(`https://api.renci.org/graphql`, {
+  return fetch(getStrapiURL("/graphql"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/lib/strapi/newsSWR.js
+++ b/lib/strapi/newsSWR.js
@@ -1,3 +1,4 @@
+import { getStrapiURL } from '@/utils/api';
 import useSWR from 'swr';
 
 export const useTags = () => {
@@ -16,7 +17,7 @@ export const useTags = () => {
     });
 
   // dedupingInterval essentially sets cache expiration time to 1 hour
-  return useSWR('https://api.renci.org/api/all-post-tags', fetcher, { dedupingInterval: 1000 * 60 * 60 });
+  return useSWR(getStrapiURL("/api/all-post-tags"), fetcher, { dedupingInterval: 1000 * 60 * 60 });
 }
 
 /**
@@ -72,7 +73,7 @@ export const useNewsArticles = ({
     excerptLength,
   }
 
-  const articlesUrl = `https://api.renci.org/api/post-list`;
+  const articlesUrl = getStrapiURL("/api/post-list");
   
   const cacheKey = JSON.stringify({articlesUrl, reqBody});
 


### PR DESCRIPTION
I'm testing the local API deployment in a local frontend deployment and realized we weren't using the `getStrapiURL` function @scrummish created. It lets you provide a URL for the API server deployment as an environment variable. This PR replaces everywhere we've hardcoded "https://api.renci.org" with that function.