### PR TITLE
Google Analytics

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -7,22 +7,18 @@ export default class MyDocument extends Document {
     return (
       <Html lang="en">
         <Head>
-          {/* <script
-            async
-            src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}`}
-          />
           <script
-            dangerouslySetInnerHTML={{
-              __html: `
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}', {
-              page_path: window.location.pathname,
-            });
-          `,
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-RFTB64LC78"
+          />
+          <script dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){ dataLayer.push(arguments); }
+              gtag('js', new Date());
+              gtag('config', 'G-RFTB64LC78');`,
             }}
-          /> */}
+          />
 
           {/* Prevent all pages from showing in search results */}
           <meta name="robots" content="noindex" />


### PR DESCRIPTION
this PR adds the analytics script tag.

note that this links this site to a distinct analytics property while the two sites are alive. also, it looks like the property ID was kept in an environment variable before, but i don't think that's necessary.