### PR TITLE
Bugfix/link tray new window

### DIFF
--- a/components/link-tray.js
+++ b/components/link-tray.js
@@ -10,7 +10,6 @@ import {
   X as TwitterIcon,
   Link as LinkIcon,
 } from '@mui/icons-material'
-import { Link } from './link'
 
 const ICONS = {
   'github.com': <GitHubIcon />,
@@ -34,10 +33,14 @@ const SocialLink = ({ to }) => {
     return (
       <Tooltip title={ `Visit ${ domain }` }>
         <IconButton
-          component={ Link }
-          to={ to }
+          component="a"
+          target="_blank"
+          rel="noopener noreferrer"
+          href={ to }
           aria-label={ `Visit ${ domain[0].toUpperCase() + domain.slice(1) }` }
-        >{ ICONS[domain] }</IconButton>
+        >
+          { ICONS[domain] }
+        </IconButton>
       </Tooltip>
     )
   }
@@ -45,10 +48,14 @@ const SocialLink = ({ to }) => {
   return (
     <Tooltip title="Visit website">
       <IconButton
-        component={ Link }
-        to={ to }
+        component="a"
+        target="_blank"
+        rel="noopener noreferrer"
+        href={ to }
         aria-label="Visit website"
-      >{ ICONS.default }</IconButton>
+      >
+        { ICONS.default }
+      </IconButton>
     </Tooltip>
   )
 }

--- a/components/link-tray.js
+++ b/components/link-tray.js
@@ -10,7 +10,7 @@ import {
   X as TwitterIcon,
   Link as LinkIcon,
 } from '@mui/icons-material'
-import { Link } from './'
+import { Link } from './link'
 
 const ICONS = {
   'github.com': <GitHubIcon />,
@@ -33,18 +33,22 @@ const SocialLink = ({ to }) => {
   if (domain in ICONS) {
     return (
       <Tooltip title={ `Visit ${ domain }` }>
-        <IconButton href={ to } aria-label={ `Visit ${ domain }` }>
-          { ICONS[domain] }
-        </IconButton>
+        <IconButton
+          component={ Link }
+          to={ to }
+          aria-label={ `Visit ${ domain[0].toUpperCase() + domain.slice(1) }` }
+        >{ ICONS[domain] }</IconButton>
       </Tooltip>
     )
   }
   // otherwise, we render a generic link icon.
   return (
     <Tooltip title="Visit website">
-      <IconButton href={ to } aria-label="Visit website">
-        { ICONS.default }
-      </IconButton>
+      <IconButton
+        component={ Link }
+        to={ to }
+        aria-label="Visit website"
+      >{ ICONS.default }</IconButton>
     </Tooltip>
   )
 }


### PR DESCRIPTION
this PR makes the social links tray link open in a new window.

simply using our `Link` component prevents the buttons from showing their tooltip normally (perhaps too many layers with our `Link` component and Next's `Link` component _and_ its required nested `a` tag). once the component receives focus, the tooltip seems to work, but that's still undesirable.

so... swapping this all out for a plain ol'  `a` tag seems to work as expected.