### PR TITLE
fix next config image domains

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   images: {
     domains: [
-      "https://dashboard.renci.org/",
+      "dashboard.renci.org",
       "radx-images.s3.amazonaws.com",
       "dashboard.sandy-web.ad.renci.org",
       "/static/images",


### PR DESCRIPTION
individual person photos were not rendering. it turns out the requests were failing. in dev, i was seeing errors like this:
```
Error: Invalid src prop [(https://dashboard.renci.org/api/webinfo/people/_ITAR-Yza0UG6lmBvnRzKcA/photo)](http://localhost:3000/people/(https://dashboard.renci.org/api/webinfo/people/_ITAR-Yza0UG6lmBvnRzKcA/photo)) on `next/image`, hostname "dashboard.renci.org" is not configured under images in your `next.config.js`
See more info: https://nextjs.org/docs/messages/next-image-unconfigured-host
```
this PR changes the dashboard domain in the image domains array in the next config and thus fixes the image issue.