### PR TITLE
allow public traffic

### DIFF
--- a/kubernetes/templates/ingress.yaml
+++ b/kubernetes/templates/ingress.yaml
@@ -6,8 +6,9 @@ metadata:
     # This only works for DNS names in public zones like *.renci.org or *.apps.renci.org. See https://wiki.renci.org/index.php/Kubernetes_Cloud/Let%27s_Encrypt_Migration
     cert-manager.io/cluster-issuer: letsencrypt
     # uncomment this line to expose to the public internet
-    # nginx.ingress.kubernetes.io/whitelist-source-range: "0.0.0.0/0,::/0"
-
+    {{- if .Values.ingress.public }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: "0.0.0.0/0,::/0"
+    {{ end }}
   name: {{ .Chart.Name }}
 spec:
   tls:

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: containers.renci.org/renci-dot-org/frontend
-  tag: "1.3.2"
+  tag: "1.4.2-beta"
 
 env:
   - name: STRAPI_ACCESS_TOKEN
@@ -27,3 +27,4 @@ service:
 
 ingress:
   host: new.renci.org
+  public: true


### PR DESCRIPTION
Allows new.renci.org to be access outside of the RENCI VPN